### PR TITLE
Baresip: Add libre/librem runtime dependencies

### DIFF
--- a/recipes-connectivity/baresip/baresip_0.5.1.bb
+++ b/recipes-connectivity/baresip/baresip_0.5.1.bb
@@ -4,6 +4,7 @@ HOMEPAGE = "http://creytiv.com/baresip.html"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://docs/COPYING;md5=b429dd27e797136d56af4dfd3ca4e9be"
 DEPENDS = "openssl libre librem alsa-lib"
+RDEPENDS_${PN} = "libre librem"
 
 SRC_URI = "https://github.com/alfredh/baresip/archive/v${PV}.tar.gz;downloadfilename=${PN}_${PV}.tar.gz"
 

--- a/recipes-connectivity/librem/librem_0.5.0.bb
+++ b/recipes-connectivity/librem/librem_0.5.0.bb
@@ -4,6 +4,7 @@ HOMEPAGE = "http://creytiv.com/rem.html"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://docs/COPYING;md5=720bf8754d76ae6c201306a8e1a36a6b"
 DEPENDS = "libre"
+RDEPENDS_${PN} = "libre"
 
 SRC_URI = "https://github.com/creytiv/rem/archive/v${PV}.tar.gz;downloadfilename=${PN}_${PV}.tar.gz"
 


### PR DESCRIPTION
When adding baresip to an image recipe, libre and librem dynamic libraries are not added automatically by the shlibs system. 

It can be fixed by the following patch.